### PR TITLE
Fix Ed25519 private key generation to comply with RFC 8032 standard

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,13 +663,13 @@
                 }
             }
 
-            // Generate a MeshCore-compatible Ed25519 keypair using the CORRECT algorithm
-            // This matches the Python implementation exactly:
+            // Generate a MeshCore-compatible Ed25519 keypair using RFC 8032 standard
+            // This follows the official Ed25519 specification:
             // 1. Generate 32-byte random seed
-            // 2. SHA512 hash the seed
-            // 3. Manually clamp the first 32 bytes (scalar clamping)
+            // 2. SHA512 hash the seed to get 64 bytes
+            // 3. Clamp the first 32 bytes (scalar clamping)
             // 4. Use crypto_scalarmult_ed25519_base_noclamp to get public key
-            // 5. Private key = [clamped_scalar][random_filler]
+            // 5. Private key = [clamped_scalar][sha512_second_half] (RFC 8032 compliant)
             async generateMeshCoreKeypair() {
                 // Ensure library is loaded
                 await this.initialize();
@@ -745,12 +745,11 @@
                     }
                 }
                 
-                // Step 5: Create 64-byte private key: [clamped_scalar][random_filler]
-                // This matches the Python implementation exactly
-                const filler = crypto.getRandomValues(new Uint8Array(32));
+                // Step 5: Create 64-byte private key: [clamped_scalar][sha512_second_half]
+                // This follows RFC 8032 Ed25519 standard: use second half of SHA-512(seed)
                 const meshcorePrivateKey = new Uint8Array(64);
-                meshcorePrivateKey.set(clamped, 0);  // First 32 bytes: clamped scalar
-                meshcorePrivateKey.set(filler, 32);  // Second 32 bytes: random filler
+                meshcorePrivateKey.set(clamped, 0);                    // First 32 bytes: clamped scalar
+                meshcorePrivateKey.set(digestArray.slice(32, 64), 32); // Second 32 bytes: SHA-512(seed)[32:64]
                 
                 return { 
                     publicKey: publicKeyBytes, 
@@ -1247,7 +1246,7 @@
             validationStatus.innerHTML = `
                 <div class="key-label">Validation Status:</div>
                 <div class="key-value" style="color: #27ae60; font-weight: bold;">
-                    ✓ Full Ed25519 validation passed - Scalar clamping, key consistency, and cryptographic verification confirmed
+                    ✓ RFC 8032 Ed25519 compliant - Proper SHA-512 expansion, scalar clamping, and key consistency verified
                 </div>
             `;
             


### PR DESCRIPTION
# Fix Ed25519 private key generation to comply with RFC 8032 standard

## Problem
The current implementation generates the 64-byte Ed25519 private key by concatenating the 32-byte clamped scalar with 32 bytes of random filler:

```javascript
const filler = crypto.getRandomValues(new Uint8Array(32));  // Random filler
const meshcorePrivateKey = new Uint8Array(64);
meshcorePrivateKey.set(clamped, 0);    // First 32 bytes: clamped scalar
meshcorePrivateKey.set(filler, 32);    // Second 32 bytes: random filler
```

This approach, while functional for MeshCore's current use case, deviates from the official Ed25519 specification and may cause interoperability issues with other Ed25519 implementations.

## Root Cause
This issue stems from a misunderstanding in my original proof-of-concept code that I shared, where I incorrectly assumed the second half should be random filler. That assumption was carried forward into this implementation.

## Solution
Updated the key generation to follow **RFC 8032 Section 5.1.5** Ed25519 standard:

```javascript
const meshcorePrivateKey = new Uint8Array(64);
meshcorePrivateKey.set(clamped, 0);                    // First 32 bytes: clamped scalar
meshcorePrivateKey.set(digestArray.slice(32, 64), 32); // Second 32 bytes: SHA-512(seed)[32:64]
```

## Technical Details
Per RFC 8032, the Ed25519 private key should contain:
- **Bytes 0-31**: Clamped scalar derived from `SHA-512(seed)[0:32]`
- **Bytes 32-63**: "Prefix" from `SHA-512(seed)[32:64]` used for deterministic nonce generation

The second half serves as input to `SHA-512(prefix || message)` during signing, ensuring deterministic signatures while maintaining security.

## Technical Verification
Evidence from MeshCore firmware signing implementation (`lib/ed25519/sign.c`):
```c
// Line 15: Uses bytes 32-63 for nonce generation
sha512_update(&hash, private_key + 32, 32);

// Line 30: Uses bytes 0-31 as private scalar
sc_muladd(signature + 32, hram, private_key, r);
```

This confirms that MeshCore uses both halves of the 64-byte private key, meaning:
- **Random filler keys**: Still work but produce non-deterministic signatures
- **RFC 8032 keys**: Produce deterministic signatures as per standard

## Impact Assessment
- **✅ Backward Compatibility**: Existing keys continue to work with MeshCore firmware. The signing implementation uses both halves of the 64-byte private key (bytes 0-31 as scalar, bytes 32-63 for nonce generation), so keys generated with random filler still produce valid signatures
- **✅ No Key Regeneration Required**: Current deployments are unaffected - signatures remain cryptographically valid regardless of whether the second half contains random data or the proper SHA-512 prefix
- **⚠️ Determinism Caveat**: Keys generated with random filler produce non-deterministic signatures (different signature for same message), while RFC 8032 compliant keys produce deterministic signatures
- **✅ Future-Proof**: Ensures compatibility with any future MeshCore features or external tools that might require deterministic Ed25519 signatures
- **✅ Standards Compliance**: Generated keys now work correctly with all RFC 8032 compliant Ed25519 implementations

## References
- [RFC 8032 - Edwards-Curve Digital Signature Algorithm (EdDSA)](https://tools.ietf.org/rfc/rfc8032.txt)
- [RFC 8032 Section 5.1.5 - Key Generation](https://tools.ietf.org/rfc/rfc8032.txt#section-5.1.5)
- [RFC 8032 Section 5.1.6 - Sign Algorithm](https://tools.ietf.org/rfc/rfc8032.txt#section-5.1.6)

## Testing
- [x] HTML syntax validation passes
- [x] Key generation algorithm verified against RFC 8032
- [x] Generated keys maintain compatibility with existing MeshCore firmware
- [x] Updated validation messages reflect RFC 8032 compliance

This change improves standards compliance without breaking existing functionality, providing a solid foundation for any future Ed25519 features while maintaining full backward compatibility.

---

*Fixes a standards compliance issue in the Ed25519 key generation algorithm originally introduced in my proof-of-concept code.*
